### PR TITLE
fix: off by one when using open_visual

### DIFF
--- a/lua/rgflow/utils.lua
+++ b/lua/rgflow/utils.lua
@@ -52,7 +52,7 @@ function M.get_visual_selection(mode)
     -- nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
     local lines = api.nvim_buf_get_lines(0, line_start, line_end, true)
     local offset = 1
-    if api.nvim_get_option("selection") ~= "inclusive" then
+    if api.nvim_get_option("selection") == "inclusive" then
         offset = 2
     end
     if mode == "v" then


### PR DESCRIPTION
Fixed off by one error when using open_visual, as noted in #26.
Thanks to [vogre](https://github.com/vogre) for pointing the bug and even providing a solution! Just making this pr to merge his fix.

| Before | After | 
| --- | --- |
| ![before](https://github.com/user-attachments/assets/6978d03a-a21d-4355-b5b2-3cb670883c6b) | ![after](https://github.com/user-attachments/assets/9937b6fd-17cd-4890-a171-c0ff0cffecf9) |